### PR TITLE
レイアウト問題若干を修正しました

### DIFF
--- a/Miraikan/Components/BaseWebView.swift
+++ b/Miraikan/Components/BaseWebView.swift
@@ -28,6 +28,10 @@
 import Foundation
 import UIKit
 
+protocol WebAccessibilityDelegate {
+    func onFinished()
+}
+
 /**
  The parent view implemented with WKNavigationDelegate
  */
@@ -39,6 +43,8 @@ class BaseWebView: BaseView, WKNavigationDelegate {
     private let gap = CGFloat(10)
     
     private var isLoadingFailed : Bool = false
+    
+    var accessibilityDelegate: WebAccessibilityDelegate?
     
     override func setup() {
         super.setup()
@@ -106,8 +112,9 @@ class BaseWebView: BaseView, WKNavigationDelegate {
     }
     
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        lblLoading.isAccessibilityElement = isLoadingFailed
         lblLoading.isHidden = !isLoadingFailed
+        lblLoading.accessibilityElementsHidden = !isLoadingFailed
+        accessibilityDelegate?.onFinished()
     }
     
 }

--- a/Miraikan/Contents/ExhibitionView.swift
+++ b/Miraikan/Contents/ExhibitionView.swift
@@ -37,8 +37,7 @@ import WebKit
  - nodeId: The destination id for navigation
  - permalink: The URL component for a specific event
  */
-class ExhibitionView: BaseWebView {
-    
+class ExhibitionView: BaseWebView, WebAccessibilityDelegate {
     private var btnNavi : StyledButton?
     private var lblDetail : AutoWrapLabel?
 
@@ -50,10 +49,12 @@ class ExhibitionView: BaseWebView {
 
     
     // MARK: init
-    init(category: String, id: String, nodeId: String?, detail : String?, locations: [ExhibitionLocation]?) {
+    init(category: String, id: String, nodeId: String?, detail : String? = nil, locations: [ExhibitionLocation]?) {
         self.id = id
         self.nodeId = nodeId
         super.init(frame: .zero)
+        
+        self.accessibilityDelegate = self
         
         btnNavi = StyledButton()
         guard let btnNavi = btnNavi else { return }
@@ -86,6 +87,7 @@ class ExhibitionView: BaseWebView {
     init(permalink: String) {
         self.id = nil
         super.init(frame: .zero)
+        self.accessibilityDelegate = self
         let address = "\(Host.miraikan.address)/\(permalink)"
         loadContent(address)
     }
@@ -112,6 +114,14 @@ class ExhibitionView: BaseWebView {
                                y: y,
                                width: innerSize.width,
                                height: innerSize.height - y)
+    }
+    
+    func onFinished() {
+        if let btnNavi = btnNavi {
+            UIAccessibility.post(notification: .screenChanged, argument: btnNavi)
+        } else {
+            UIAccessibility.post(notification: .screenChanged, argument: self.parentVC?.title)
+        }
     }
     
 }

--- a/Miraikan/Home.swift
+++ b/Miraikan/Home.swift
@@ -471,6 +471,15 @@ class Home : BaseListView {
         items = menuItems
     }
     
+    override func layoutSubviews() {
+        guard let tabBar = self.tabVC else { return }
+        let tableHeight = innerSize.height - tabBar.tabBar.frame.height - insets.bottom
+        tableView.frame = CGRect(x: insets.left,
+                                 y: insets.top,
+                                 width: innerSize.width,
+                                 height: tableHeight)
+    }
+    
     // MARK: UITableViewDataSource
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let (sec, row) = (indexPath.section, indexPath.row)

--- a/Miraikan/Lists/PermanentExhibitionController.swift
+++ b/Miraikan/Lists/PermanentExhibitionController.swift
@@ -155,10 +155,11 @@ class PermanentExhibitionController : BaseListController, BaseListDelegate {
     
     override func onSelect(_ tableView: UITableView, _ indexPath: IndexPath) {
         // Only the link is clickable
-//        if let model = items?[indexPath.section]?[indexPath.row] as? RegularExhibitionModel {
         if let model = (items as? [Any])?[indexPath.row] as? RegularExhibitionModel {
             guard let nav = self.navigationController as? BaseNavController else { return }
-            let vc = ExhibitionListController(id: model.id, title: model.title)
+            let vc = MiraikanUtil.routeMode == .blind
+            ? BlindExhibitionController(id: model.id, title: model.title)
+            : ExhibitionListController(id: model.id, title: model.title)
             nav.show(vc, sender: nil)
         }
     }

--- a/NavCog3.xcodeproj/project.pbxproj
+++ b/NavCog3.xcodeproj/project.pbxproj
@@ -254,6 +254,7 @@
 		D364735F273E0D4400C110B0 /* EventListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D364735D273E0D4400C110B0 /* EventListController.swift */; };
 		D364736D273E140C00C110B0 /* Home.swift in Sources */ = {isa = PBXBuildFile; fileRef = D364736C273E140C00C110B0 /* Home.swift */; };
 		D3921C30275760DF00F1DD55 /* BlankView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3921C2F275760DF00F1DD55 /* BlankView.swift */; };
+		D39F3C2E27730ACD0014F1CE /* BlindExhibitionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39F3C2D27730ACD0014F1CE /* BlindExhibitionController.swift */; };
 		D3A117EE27294B0B00BEC1C8 /* NavDataStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E0E97151D98B80100CF2960 /* NavDataStore.m */; };
 		D3A117EF27294B0B00BEC1C8 /* ServerConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EF45E371E3F1E5600208042 /* ServerConfig.m */; };
 		D3A117F027294B0B00BEC1C8 /* AgreementViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EF45E2A1E3F1E3700208042 /* AgreementViewController.m */; };
@@ -648,6 +649,7 @@
 		D38EF87A2704072A00DB9444 /* ExhibitionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExhibitionView.swift; sourceTree = "<group>"; };
 		D38EF87E2704492000DB9444 /* HLPHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HLPHelper.h; sourceTree = "<group>"; };
 		D3921C2F275760DF00F1DD55 /* BlankView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlankView.swift; sourceTree = "<group>"; };
+		D39F3C2D27730ACD0014F1CE /* BlindExhibitionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlindExhibitionController.swift; sourceTree = "<group>"; };
 		D3A1185927294B0B00BEC1C8 /* NavCogMiraikan.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NavCogMiraikan.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3A1185B272950B400BEC1C8 /* Miraikan.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Miraikan.plist; sourceTree = "<group>"; };
 		D3A156EE27200BE300A23B9E /* MiraikanMapController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MiraikanMapController.h; sourceTree = "<group>"; };
@@ -1150,6 +1152,7 @@
 			children = (
 				D364735D273E0D4400C110B0 /* EventListController.swift */,
 				D364735C273E0D4400C110B0 /* ExhibitionListController.swift */,
+				D39F3C2D27730ACD0014F1CE /* BlindExhibitionController.swift */,
 				D3083C79275603CA0052ABEE /* PermanentExhibitionController.swift */,
 				D3A575D8270BF59C00E9850A /* FloorSelectionController.swift */,
 			);
@@ -2126,6 +2129,7 @@
 				D3A1180B27294B0B00BEC1C8 /* NavPreviewer.m in Sources */,
 				D364736D273E140C00C110B0 /* Home.swift in Sources */,
 				D3A1180C27294B0B00BEC1C8 /* FloorMapView.swift in Sources */,
+				D39F3C2E27730ACD0014F1CE /* BlindExhibitionController.swift in Sources */,
 				D3A1180D27294B0B00BEC1C8 /* ScreenshotHelper.m in Sources */,
 				D3A1180E27294B0B00BEC1C8 /* WelcomViewController.m in Sources */,
 				D3A1180F27294B0B00BEC1C8 /* HLPSettingTableView.m in Sources */,


### PR DESCRIPTION
**古いバグ**：VoiceOver で「常設展示」を開けない

原因：tableView の下部は一部 tab に隠れて、文字を見えるが、タップ動作は効かなかった。

更新：tableView のサイズを修正し、下部に到着すると自動スクロールになります。

#21: 

更新：Home と同じ方法でタイトルをフォカスさせたが、戻るボタンにしかフォカスできない。

#22:

展示名を見出しにすること：tableView に不自然な設計で、一時放置

その他：更新済