### PR TITLE
Fixed a bug that the location information function does not work at the first start

### DIFF
--- a/Miraikan/Lists/MiraikanController.swift
+++ b/Miraikan/Lists/MiraikanController.swift
@@ -75,16 +75,6 @@ class MiraikanController: BaseController {
         }
         self.navigationItem.rightBarButtonItem = btnSetting
         
-        // Request local notification permission
-        UNUserNotificationCenter.current()
-            .requestAuthorization(options: [.alert, .sound, .badge],
-                                  completionHandler: { (granted, error) in
-                print("Authorization granted: \(granted)")
-                if let _err = error {
-                    print(_err.localizedDescription)
-                }
-            })
-        
         // TODO: Initialization processing position needs to be changed
         // Load the data
         if let events = MiraikanUtil.readJSONFile(filename: "event",
@@ -97,58 +87,9 @@ class MiraikanController: BaseController {
             if !MiraikanUtil.isWeekend { schedules.removeAll(where: { $0.onHoliday == false }) }
             ExhibitionDataStore.shared.schedules = schedules
 
-//            // Add local notifications
-//            schedules.forEach({ schedule in
-//                if schedule.place == "co_studio" {
-//                    let scheduledTime = schedule.time.split(separator: ":")
-//                    var components = DateComponents()
-//                    components.calendar = .current
-//                    // Show notification 5 minutes before the event
-//                    let PREV_MINS = 5
-//                    let ONE_HOUR = 60
-//                    let minute = Int(scheduledTime[1])! - PREV_MINS
-//                    components.minute = minute >= 0 ? minute : ONE_HOUR + minute
-//                    let hour = Int(scheduledTime[0])!
-//                    components.hour = minute >= 0 ? hour : hour - 1
-//
-//                    let content = UNMutableNotificationContent()
-//                    content.title = "コ・スタジオトークに参加します"
-//                    guard let talkTitle = ExhibitionDataStore.shared.events?
-//                        .first(where: { $0.id == schedule.event })?.talkTitle
-//                    else { return }
-//                    content.body = "\(talkTitle)"
-//
-//                    let calendar = Calendar(identifier: .gregorian)
-//                    let date = calendar.date(bySettingHour: hour, minute: minute, second: 0, of: Date())
-//                    var title: String?
-//                    var nodeId: String?
-//                    if let floorMaps = MiraikanUtil.readJSONFile(filename: "floor_map",
-//                                                                 type: [FloorMapModel].self) as? [FloorMapModel],
-//                       let floorMap = floorMaps.first(where: {$0.id == schedule.place }) {
-//                        title = floorMap.title
-//                        nodeId = floorMap.nodeId
-//                    }
-//                    content.userInfo = [
-//                        "year": date ?? Date(),
-//                        "eventId": schedule.event,
-//                        "nodeId": nodeId ?? "",
-//                        "facilityId": schedule.place,
-//                        "title": title ?? ""
-//                    ]
-//
-//                    let trigger = UNCalendarNotificationTrigger(dateMatching: components,
-//                                                                repeats: false)
-//                    let request = UNNotificationRequest(identifier: schedule.event,
-//                                                        content: content,
-//                                                        trigger: trigger)
-//                    UNUserNotificationCenter.current().add(request, withCompletionHandler: { error in
-//                        if let _err = error {
-//                            print(_err.localizedDescription)
-//                        }
-//                    })
-//                }
-//            })
         }
+        
+        MiraikanUtil.startLocating()
     }
 
     @objc func getDestinations(note: Notification) {

--- a/NavCog3/AppDelegate.h
+++ b/NavCog3/AppDelegate.h
@@ -23,14 +23,13 @@
 
 
 #import <UIKit/UIKit.h>
-#import <CoreBluetooth/CoreBluetooth.h>
 #import <HLPLocationManager/HLPLocationManager.h>
 #import <WebKit/WebKit.h>
 #import <UserNotifications/UserNotifications.h>
 #import <NavCogMiraikan-Swift.h>
 
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate, CBCentralManagerDelegate, UNUserNotificationCenterDelegate, HLPLocationManagerDelegate>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, UNUserNotificationCenterDelegate, HLPLocationManagerDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
 @property UIBackgroundTaskIdentifier backgroundID;

--- a/NavCog3/LocationEvent.h
+++ b/NavCog3/LocationEvent.h
@@ -48,6 +48,7 @@
 #define CALIBRATION_BEACON_FOUND @"calibration_beacon_found_notification"
 
 #define REQUEST_RSSI_BIAS @"request_rssi_bias_notification"
+#define REQUEST_LOCATION_INIT @"REQUEST_LOCATION_INIT"
 #define REQUEST_LOCATION_HEADING_RESET @"request_location_heading_reset_notification"
 #define REQUEST_LOCATION_RESET @"request_location_reset_notification"
 #define REQUEST_LOCATION_RESTART @"request_location_restart"
@@ -98,5 +99,7 @@
 #define REQUEST_RATING @"REQUEST_RATING"
 
 #define REQUEST_UNLOAD_VIEW @"REQUEST_UNLOAD_VIEW"
+
+#define DATA_INITIALIZE_RESTART @"DATA_INITIALIZE_RESTART"
 
 #endif /* LocationEvent_h */

--- a/NavCog3/ServerConfig.h
+++ b/NavCog3/ServerConfig.h
@@ -88,4 +88,6 @@ typedef NSArray<ServerEntry*> ServerList;
 
 - (NSArray* _Nullable) extraMenuList;
 - (NSString*_Nonnull)convertRelativePath:(NSString*_Nonnull)orig;
+- (void)setDataDownloaded:(BOOL) isCompleted;
+- (BOOL)checkDataDownloaded;
 @end

--- a/NavCog3/ServerConfig.m
+++ b/NavCog3/ServerConfig.m
@@ -530,4 +530,13 @@ static ServerConfig *instance;
     
     return _extraMenuConfig;
 }
+
+- (void)setDataDownloaded:(BOOL) isCompleted {
+    [[NSUserDefaults standardUserDefaults] setBool:isCompleted forKey:@"data_downloaded"];
+}
+
+- (BOOL)checkDataDownloaded {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"data_downloaded"];
+}
+
 @end

--- a/NavCog3/WelcomViewController.h
+++ b/NavCog3/WelcomViewController.h
@@ -23,8 +23,11 @@
 
 #import <UIKit/UIKit.h>
 #import <NavCogMiraikan-Swift.h>
+#import <CoreBluetooth/CoreBluetooth.h>
+#import <CoreLocation/CoreLocation.h>
+#import <UserNotifications/UserNotifications.h>
 
-@interface WelcomViewController : UIViewController
+@interface WelcomViewController : UIViewController  <CBCentralManagerDelegate, CLLocationManagerDelegate>
 @property (weak, nonatomic) IBOutlet UILabel *statusLabel;
 @property (weak, nonatomic) IBOutlet UIButton *retryButton;
 


### PR DESCRIPTION
初回起動時は位置情報許可を行っても、位置情報が取得できない不具合が存在するため、その対策。
初回起動時の位置情報利用許可、Bluetooth利用許可、通知利用許可の許可タイミングをデータダウンロード、初期化などのタイミングを調整する必要がある。
Bluetooth利用許可、初回起動時の位置情報利用許可、通知利用許可の許可ダイアログ完了しないと進めないように変更
許可ダイアログ後にデータダウンロードを行い、位置情報機能の初期化実施を行う。
許可しない場合や一度アプリから抜けて復帰する場合の調整を行なった。

室内位置情報ライブラリHLPLocationManagerの初期化と開始は正確な仕様が不明のため、既存実装から参照しています。